### PR TITLE
Adding support for multiple parameters other than message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,48 +1,49 @@
 {
-    "name": "grunt-slack-hook",
-    "description": "Grunt plugin that can push messages to slack.com service using web hooks.",
-    "version": "0.0.4",
-    "homepage": "https://github.com/pwalczyszyn/grunt-slack-hook",
-    "author": {
-        "name": "Piotr Walczyszyn",
-        "email": "piotr@outof.me",
-        "url": "http://outof.me"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/pwalczyszyn/grunt-slack-hook.git"
-    },
-    "bugs": {
-        "url": "https://github.com/pwalczyszyn/grunt-slack-hook/issues"
-    },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/pwalczyszyn/grunt-slack-hook/blob/master/LICENSE-MIT"
+  "name": "grunt-slack-hook",
+  "description": "Grunt plugin that can push messages to slack.com service using web hooks.",
+  "version": "0.0.4",
+  "homepage": "https://github.com/pwalczyszyn/grunt-slack-hook",
+  "author": {
+    "name": "Piotr Walczyszyn",
+    "email": "piotr@outof.me",
+    "url": "http://outof.me"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pwalczyszyn/grunt-slack-hook.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pwalczyszyn/grunt-slack-hook/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/pwalczyszyn/grunt-slack-hook/blob/master/LICENSE-MIT"
     }
-    ],
-    "main": "Gruntfile.js",
-    "engines": {
-        "node": ">= 0.8.0"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "dependencies": {
-        "superagent": "~0.15.7"
-    },
-    "devDependencies": {
-        "grunt-contrib-jshint": "~0.6.0",
-        "grunt-contrib-clean": "~0.4.0",
-        "grunt-contrib-nodeunit": "~0.2.0",
-        "grunt": "~0.4.2"
-    },
-    "peerDependencies": {
-        "grunt": "~0.4.2"
-    },
-    "keywords": [
+  ],
+  "main": "Gruntfile.js",
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "lodash.template": "^4.4.0",
+    "superagent": "~0.15.7"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-nodeunit": "~0.2.0",
+    "grunt": "~0.4.2"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.2"
+  },
+  "keywords": [
     "slack",
     "grunt",
     "web hook"
-    ]
+  ]
 }

--- a/tasks/slack.js
+++ b/tasks/slack.js
@@ -1,5 +1,6 @@
 /* jshint node:true */
 var request = require('superagent');
+var template = require('lodash.template');
 
 module.exports = function(grunt) {
 
@@ -15,11 +16,15 @@ module.exports = function(grunt) {
             return;
         }
 
-        var done = this.async(),
-            message = grunt.option('message') || '',
-            data = {
-                text: this.data.text.replace('{{message}}', message)
-            };
+
+        var done = this.async();
+
+        var buildText = template(this.data.text, { interpolate: /{{([\s\S]+?)}}/g });
+
+        grunt.cli.options.message = grunt.option('message') || '';
+        var data = {
+            text: buildText(grunt.cli.options)
+        };
 
         if(options.channel){
             data.channel = options.channel;


### PR DESCRIPTION
Now you can pass to slack only `message`, this commit enables passing multiple parameters.

For example:
`grunt slack:deployed --env "prod" --initiator "yosi"`
and use it like this:
`text: "Finished deployment {{env}} by {{initiator}}"`